### PR TITLE
Updated pushes.R to fix space in sprintf call per #11.

### DIFF
--- a/R/pushes.R
+++ b/R/pushes.R
@@ -127,7 +127,7 @@ pbPost <- function(type=c("note", "link", "address", "file"),
             
             # Upload File
             txt <- sprintf(paste0("%s -i %s -F awsaccesskeyid='%s' -F acl='%s' ",
-                                  "-F key='%s' -F signature='%s' -F policy='%s'",
+                                  "-F key='%s' -F signature='%s' -F policy='%s' ",
                                   "-F content-type='%s' -F 'file=@%s'"),
                            curl, 
                            uploadrequest$upload_url,


### PR DESCRIPTION
Per #11, unable to upload when content-type was specified. 
There appeared to be a missing space on line 130. When testing this command with the fix, this appears to resolve the issue for me.
