### PR TITLE
Add support for 'channel' argument.

### DIFF
--- a/R/pushes.R
+++ b/R/pushes.R
@@ -66,6 +66,9 @@
 ##' @param email An alternative way to specify a recipient is to specify 
 ##' an email address. If both \code{recipients} and \code{email} are
 ##' present, \code{recipients} is used.
+##' @param channel A channel tag used to specify the name of the channel
+##' as the recipient. If either \code{recipients} or \code{email} are present,
+##' they will take precedence over \code{channel}.
 ##' @param deviceind (Deprecated) The index (or a vector/list of indices) of the
 ##' device(s) in the list of devices. 
 ##' @param apikey The API key used to access the service. It can be
@@ -104,6 +107,7 @@ pbPost <- function(type=c("note", "link", "address", "file"),
                    filetype="text/plain",# file type for upload of type='file'
                    recipients,           # devices to post to
                    email,                # alternatively use an email
+		   channel,              # alternatively specify a channel
                    deviceind,            # deprecated, see detail
                    apikey = .getKey(),
                    devices = .getDevices(),
@@ -112,16 +116,16 @@ pbPost <- function(type=c("note", "link", "address", "file"),
     type <- match.arg(type)
 
     if (!missing(deviceind)) {
-        if (missing(recipients) && missing(email)) {
+	if (missing(recipients) && missing(email) && missing(channel)) {
             warning("Agument 'deviceind' is deprecated. Please use 'recipients'.", call.=FALSE)
             recipients <- deviceind
         } else {
-            warning("Using 'recipients' (or 'email') and ignoring deprecated 'deviceinds'.",
+	    warning("Using 'recipients' (or 'email' or 'channel') and ignoring deprecated 'deviceinds'.",
                     call.=FALSE)
         }
     }
 
-    if (missing(recipients) && missing(email)) {
+    if (missing(recipients) && missing(email) && missing(channel)) {
         recipients <- .getDefaultDevice() # either supplied, or 0 as fallback
 	if(recipients==0) {
 	    dest <- ''
@@ -135,8 +139,13 @@ pbPost <- function(type=c("note", "link", "address", "file"),
             } else {
                 dest <- recipients      # numeric values
             }
-        } else {                        # hence email presnt
-           dest <- email
+	} else {                        # either email or channel present
+	    if(!missing(email)) {
+		dest <- email
+	    } else {                    # hence channel present
+		dest <- channel
+		email <- NA # Set e-mail to NA, missing() is unreliable
+	    }
        }
     }
     
@@ -176,8 +185,12 @@ pbPost <- function(type=c("note", "link", "address", "file"),
     }
 
     ret <- lapply(dest, function(d) {
-        if (is.character(d)) {          # this was an email
-            tgt <- sprintf(' -d email="%s" ', d)
+	if (is.character(d)) {          # this is an email or channel.
+	    if(!is.na(email)){
+		tgt <- sprintf(' -d email="%s" ', d)
+	    } else {                    # hence assume channel
+		tgt <- sprintf(' -d channel_tag="%s" ', d)
+	    }
         } else if (is.numeric(d)) {     # this a listed device, now transfered to index
             tgt <- ifelse(d == 0,       # if zero, then use all devices
                           '',           # otherwise given specific device

--- a/tests/simpleTests.R
+++ b/tests/simpleTests.R
@@ -32,7 +32,7 @@ if (Sys.getenv("Run_RPushbullet_Tests")=="yes") {
     res <- fromJSON(pbPost("note", "A Simple Test",
                            "We think this should work.\nWe really do.")[[1]])
     str(res)
-    ## storing this test result to allow us to use active user's email for testing below.
+    ## storing this test result to allow us to use active user's email for testing below. 
 
 
     ## Post an address -- should open browser in Google Maps
@@ -47,7 +47,7 @@ if (Sys.getenv("Run_RPushbullet_Tests")=="yes") {
 
     ## we use this file several times below
     descfile <- system.file("DESCRIPTION", package="RPushbullet")
-
+    
     ## Post a file with no recipients
     str(fromJSON(pbPost(type="file", url=descfile)[[1]]))
 
@@ -60,7 +60,6 @@ if (Sys.getenv("Run_RPushbullet_Tests")=="yes") {
 
     ## Post a file with an email recipient specified:
     str(fromJSON(pbPost(type="file", url=descfile, email = res$receiver_email)[[1]]))
-
 
     ## Post file with both email and numeric recipient specified:
     str(fromJSON(pbPost(type="file", url=descfile, recipients = RPushbullet:::.getNames()[1],

--- a/tests/simpleTests.R
+++ b/tests/simpleTests.R
@@ -65,4 +65,32 @@ if (Sys.getenv("Run_RPushbullet_Tests")=="yes") {
     str(fromJSON(pbPost(type="file", url=descfile, recipients = RPushbullet:::.getNames()[1],
                         email = res$receiver_email)[[1]]))
 
+    ## Test hierarchy of arguments with channel specified:
+    ## 1) All three should send to recipients.
+    ## 2) Email and channel should send to email.
+    ## 3) Recipients and channel should send to recipients
+    ## 4) Only channel should send to channel.
+
+    ## Post a note with recipients, email and channel specified.
+    result<-fromJSON(pbPost(type="note","A Simple Test","We think this should work.\nWe really do.",recipients = RPushbullet:::.getNames()[1],email = "mike.birdgeneau@gmail.com",channel = "rpushbullet_test")[[1]])
+    if(is.null(result$target_device_iden)){
+	stop("Test Failed.")
+    }
+
+    ## Post a note with email and channel specified.
+    result<-fromJSON(pbPost(type="note","A Simple Test","We think this should work.\nWe really do.",email = "mike.birdgeneau@gmail.com",channel = "rpushbullet_test")[[1]])
+    if(is.null(result$receiver_email)){
+	stop("Test Failed.")
+    }
+
+    ## Post a note with recipients and channel specified.
+    result<-fromJSON(pbPost(type="note","A Simple Test","We think this should work.\nWe really do.",recipients = RPushbullet:::.getNames()[1],channel = "rpushbullet_test")[[1]])
+    if(is.null(result$target_device_iden)){
+	stop("Test Failed.")
+    }
+
+    ## Post a note with only the channel specified.
+    str(fromJSON(pbPost(type="note","A Simple Test","We think this should work.\nWe really do.",channel = "rpushbullet_test",verbose=TRUE)[[1]]))
+    # Returns empty list, but posts successfully. API seems to return empty JSON. (tested curl command)
+
 }


### PR DESCRIPTION
Per #18, adding code to support channels:

1) Added documentation to Readme.md regarding channels. (this will need a slight update once functionality is implemented).
2) Added `channel` argument to `pbPost()` in `pushes.R`.
3) Added logic to handle `channel` argument using the messaging > email > channel hierarchy.
4) Added to curl command to push to a channel.
4) Added tests to `simpleTests.R` to handle channel & test hierarchy.

Commit 8040f74 covers most of these changes. (57ebf50 has the changes to Readme.md)