### PR TITLE
fix to write single elements as vectors instead of lists when using j…

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -66,7 +66,7 @@ pbSetup <- function(apikey, conffile) {
     if (defdev %in% as.character(seq_along(names)))
         reslist$defaultdevice <- names[as.integer(defdev)]
 
-    json <- toJSON(reslist)
+    json <- toJSON(reslist, auto_unbox = TRUE)
 
     f <- file(conffile,open = "w")
     cat(json,file = f)


### PR DESCRIPTION
…sonlite::toJSON in pbSetup.  pbSetup is the only function in the package that calls to toJSON at the moment.