### PR TITLE
Update init.R to fix issue # 57

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -89,6 +89,7 @@
 .getCurlHandle <- function(apikey){
     h <- curl::new_handle()
     curl::handle_setheaders(h, .list=list('Access-Token' = apikey))
+    curl::handle_setopt(h,http_version = 2)   
     return(h)
 }
 


### PR DESCRIPTION
Changed .getCurlHandle() to make it use HTTP v1.1 instead of v2.0. This change has resolved my issue where pbPost() would randomly fail due to an an HTTP2 framing layer issue caused by curl::curl_fetch_memory(pburl, handle=h)